### PR TITLE
Update `--color-accent-fg` according to spec

### DIFF
--- a/style.user.css
+++ b/style.user.css
@@ -325,7 +325,7 @@ background-color: draculaW-blackSecondary
         --color-neutral-emphasis: #6e7681;
         --color-neutral-muted: rgba(110, 118, 129, 0.4);
         --color-neutral-subtle: rgba(110, 118, 129, 0.1);
-        --color-accent-fg: #58a6ff;
+        --color-accent-fg: #8be9fd;
         --color-accent-emphasis: #bd93f9;
         --color-accent-muted: rgba(56, 139, 253, 0.4);
         --color-accent-subtle: rgba(56, 139, 253, 0.15);


### PR DESCRIPTION
According to the spec [here](https://spec.draculatheme.com/#MarkupLinkUrl), links should be cyan (`#8be9fd`)…