### PR TITLE
Update GitHub Actions checks input placeholder

### DIFF
--- a/style.user.css
+++ b/style.user.css
@@ -24,17 +24,11 @@ background-color: draculaW-blackSecondary
 
 */
 @-moz-document domain("github.com") {
-  /* Replace default github colors */
-  [data-color-mode="light"][data-light-theme="light"], // Light default
-    [data-color-mode="dark"][data-dark-theme="light"],
-    [data-color-mode="light"][data-light-theme="dark"], // Dark default
-    [data-color-mode="dark"][data-dark-theme="dark"],
-    [data-color-mode="light"][data-light-theme="dark_high_contrast"], // Dark high contrast
-    [data-color-mode="dark"][data-dark-theme="dark_high_contrast"],
-    [data-color-mode="light"][data-light-theme="dark_dimmed"], //Dark dimmed
-    [data-color-mode="dark"][data-dark-theme="dark_dimmed"],
-    [data-color-mode=auto][data-light-theme*=light], //Auto colors
-    [data-color-mode=auto][data-light-theme*=dark] {
+  /* Replace default github colors. Need the attributes here to match the specificity of the default values. */
+  html[data-color-mode][data-light-theme],
+  html[data-color-mode][data-dark-theme],
+  html[data-color-mode][data-light-theme] body,
+  html[data-color-mode][data-dark-theme] body {
     --color-canvas-default-transparent: rgba(13, 17, 23, 0);
     --color-page-header-bg: #282a36;
     --color-marketing-icon-primary: #79c0ff;

--- a/style.user.css
+++ b/style.user.css
@@ -115,7 +115,7 @@ background-color: draculaW-blackSecondary
         --color-checks-btn-hover-icon: #c9d1d9;
         --color-checks-btn-hover-bg: rgba(110, 118, 129, 0.1);
         --color-checks-input-text: #f8f8f2;
-        --color-checks-input-placeholder-text: #484f58;
+        --color-checks-input-placeholder-text: #8b949e;
         --color-checks-input-focus-text: #c9d1d9;
         --color-checks-input-bg: #44475a;
         --color-checks-input-shadow: 0 0 0 1px;


### PR DESCRIPTION
The colour currently used for the placeholder text is very low-contrast and difficult to read. Updated to a lighter colour from the palette to improve legibility

Before:
<img width="1353" alt="before" src="https://user-images.githubusercontent.com/3133657/218740339-cea3535f-0beb-40d5-b510-0aa6c2432970.png">

After:
<img width="1353" alt="after" src="https://user-images.githubusercontent.com/3133657/218740368-12640004-98e1-43b5-be05-377168b4d3f5.png">


