### PR TITLE
Fix variables not being applied

### DIFF
--- a/style.user.css
+++ b/style.user.css
@@ -26,7 +26,9 @@ background-color: draculaW-blackSecondary
 @-moz-document domain("github.com") {
     /* Replace default github colors. Need the attributes here to match the specificity of the default values. */
     html[data-color-mode][data-light-theme],
-    html[data-color-mode][data-light-theme] body {
+    html[data-color-mode][data-dark-theme],
+    html[data-color-mode][data-light-theme] body,
+    html[data-color-mode][data-dark-theme] body {
         --color-canvas-default-transparent: rgba(13, 17, 23, 0);
         --color-page-header-bg: #282a36;
         --color-marketing-icon-primary: #79c0ff;

--- a/style.user.css
+++ b/style.user.css
@@ -24,17 +24,9 @@ background-color: draculaW-blackSecondary
 
 */
 @-moz-document domain("github.com") {
-    /* Replace default github colors */
-    [data-color-mode="light"][data-light-theme="light"] body, // Light default
-    [data-color-mode="dark"][data-dark-theme="light"] body,
-    [data-color-mode="light"][data-light-theme="dark"] body, // Dark default
-    [data-color-mode="dark"][data-dark-theme="dark"] body,
-    [data-color-mode="light"][data-light-theme="dark_high_contrast"] body, // Dark high contrast
-    [data-color-mode="dark"][data-dark-theme="dark_high_contrast"] body,
-    [data-color-mode="light"][data-light-theme="dark_dimmed"] body, // Dark dimmed
-    [data-color-mode="dark"][data-dark-theme="dark_dimmed"] body,
-    [data-color-mode=auto][data-light-theme*=light] body, // Auto colors
-    [data-color-mode=auto][data-light-theme*=dark] body {
+    /* Replace default github colors. Need the attributes here to match the specificity of the default values. */
+    html[data-color-mode][data-light-theme],
+    html[data-color-mode][data-light-theme] body {
         --color-canvas-default-transparent: rgba(13, 17, 23, 0);
         --color-page-header-bg: #282a36;
         --color-marketing-icon-primary: #79c0ff;

--- a/style.user.css
+++ b/style.user.css
@@ -25,16 +25,16 @@ background-color: draculaW-blackSecondary
 */
 @-moz-document domain("github.com") {
     /* Replace default github colors */
-    [data-color-mode="light"][data-light-theme="light"], // Light default
-    [data-color-mode="dark"][data-dark-theme="light"],
-    [data-color-mode="light"][data-light-theme="dark"], // Dark default
-    [data-color-mode="dark"][data-dark-theme="dark"],
-    [data-color-mode="light"][data-light-theme="dark_high_contrast"], // Dark high contrast
-    [data-color-mode="dark"][data-dark-theme="dark_high_contrast"],
-    [data-color-mode="light"][data-light-theme="dark_dimmed"], //Dark dimmed
-    [data-color-mode="dark"][data-dark-theme="dark_dimmed"],
-    [data-color-mode=auto][data-light-theme*=light], //Auto colors
-    [data-color-mode=auto][data-light-theme*=dark]{
+    [data-color-mode="light"][data-light-theme="light"] body, // Light default
+    [data-color-mode="dark"][data-dark-theme="light"] body,
+    [data-color-mode="light"][data-light-theme="dark"] body, // Dark default
+    [data-color-mode="dark"][data-dark-theme="dark"] body,
+    [data-color-mode="light"][data-light-theme="dark_high_contrast"] body, // Dark high contrast
+    [data-color-mode="dark"][data-dark-theme="dark_high_contrast"] body,
+    [data-color-mode="light"][data-light-theme="dark_dimmed"] body, // Dark dimmed
+    [data-color-mode="dark"][data-dark-theme="dark_dimmed"] body,
+    [data-color-mode=auto][data-light-theme*=light] body, // Auto colors
+    [data-color-mode=auto][data-light-theme*=dark] body {
         --color-canvas-default-transparent: rgba(13, 17, 23, 0);
         --color-page-header-bg: #282a36;
         --color-marketing-icon-primary: #79c0ff;


### PR DESCRIPTION
The default colors were overriding these so they weren't actually being applied. It looks like the default colors are applied on `body` (not sure if that was the case before or not), so moving the custom styles also to `body` fixes the issue, though we also need to keep them on `html` to style the full background of the page.